### PR TITLE
Adding support for Tmux configuration serialization

### DIFF
--- a/symphony/kube/experiment.py
+++ b/symphony/kube/experiment.py
@@ -1,6 +1,7 @@
 import copy
 from symphony.spec import ExperimentSpec
 from symphony.engine.address_book import AddressBook
+from symphony.utils.common import compact_range_dumps, compact_range_loads
 from symphony.utils.common import sanitize_name_kubernetes
 from .process import KubeProcessSpec
 from .process_group import KubeProcessGroupSpec
@@ -123,34 +124,3 @@ class KubeExperimentSpec(ExperimentSpec):
         data['port_range'] = compact_range_dumps(self.port_range)
         return data
 
-
-def compact_range_dumps(li):
-    """
-    Accepts a list of integers and represent it as intervals
-    [1,2,3,4,6,7] => '1-4,6-7'
-    """
-    li = sorted(li)
-    low = None
-    high = None
-    collections = []
-    for i,number in enumerate(li):
-        number = li[i]
-        if low is None:
-            low = number
-            high = number
-        elif high + 1 == number:
-            high = number
-        else:
-            collections.append('{}-{}'.format(low, high))
-            low = None
-            high = None
-    collections.append('{}-{}'.format(low, high))
-    return ','.join(collections)
-
-
-def compact_range_loads(description):
-    specs = [x.split('-') for x in description.split(',')]
-    li = []
-    for low, high in specs:
-        li += list(range(int(low), int(high)))
-    return li

--- a/symphony/tmux/process.py
+++ b/symphony/tmux/process.py
@@ -35,9 +35,13 @@ class TmuxProcessSpec(ProcessSpec):
         for k, v in di.items():
             self.env[k] = str(v)
 
-    @classmethod
-    def load_dict(cls):
-        pass
+    def _load_dict(self, di):
+        super()._load_dict(di)
+        self.start_dir = di['start_dir']
+        self.cmds = di['cmds']
 
     def dump_dict(self):
-        pass
+        di = super().dump_dict()
+        di['start_dir'] = self.start_dir
+        di['cmds'] = self.cmds
+        return di

--- a/symphony/tmux/process_group.py
+++ b/symphony/tmux/process_group.py
@@ -32,9 +32,13 @@ class TmuxProcessGroupSpec(ProcessGroupSpec):
     def _new_process(self, *args, **kwargs):
         return TmuxProcessSpec(*args, **kwargs)
 
-    @classmethod
-    def load_dict(cls):
-        pass
+    def _load_dict(self, di):
+        super()._load_dict(di)
+        self.start_dir = di['start_dir']
+        self.preamble_cmds = di['preamble_cmds']
 
     def dump_dict(self):
-        pass
+        di = super().dump_dict()
+        di['start_dir'] = self.start_dir
+        di['preamble_cmds'] = self.preamble_cmds
+        return di

--- a/symphony/utils/common.py
+++ b/symphony/utils/common.py
@@ -83,3 +83,33 @@ def deduplicate_with_order(seq):
     deduplicate list while preserving order
     """
     return list(OrderedDict.fromkeys(seq))
+
+def compact_range_dumps(li):
+    """
+    Accepts a list of integers and represent it as intervals
+    [1,2,3,4,6,7] => '1-4,6-7'
+    """
+    li = sorted(li)
+    low = None
+    high = None
+    collections = []
+    for i,number in enumerate(li):
+        number = li[i]
+        if low is None:
+            low = number
+            high = number
+        elif high + 1 == number:
+            high = number
+        else:
+            collections.append('{}-{}'.format(low, high))
+            low = None
+            high = None
+    collections.append('{}-{}'.format(low, high))
+    return ','.join(collections)
+
+def compact_range_loads(description):
+    specs = [x.split('-') for x in description.split(',')]
+    li = []
+    for low, high in specs:
+        li += list(range(int(low), int(high)+1))
+    return li


### PR DESCRIPTION
@jirenz : I moved the `compact_range_{dump,load}` stuff to `symphony.utils.common` and fixed a minor bug (when loading a range like `1-4`, it only loads `1, 2, 3` because the added range was defined to be `range(int(low), int(high))`.