### PR TITLE
Changes to signal handling to avoid orphan processes

### DIFF
--- a/symphony/subproc/manager.py
+++ b/symphony/subproc/manager.py
@@ -74,7 +74,8 @@ class SubprocManager:
             universal_newlines=True,  # force text stream
             stdout=stdout,
             stderr=stderr,
-            env=env
+            env=env,
+            preexec_fn=os.setsid
         )
         self.processes[name] = proc
         return proc
@@ -95,9 +96,10 @@ class SubprocManager:
     def kill(self, name, signal=signal.SIGTERM, verbose=False):
         if self.poll(name) is None:
             proc = self.processes[name]
-            os.kill(proc.pid, signal.SIGTERM)
+            group = os.getpgid(proc.pid)
+            os.killpg(group, signal)
             if verbose:
-                print('Sent', self.SIG_DICT[signal], 'to', proc.pid)
+                print('Sent', self.SIG_DICT[signal], 'to group', group)
 
     def kill_all(self, verbose=False):
         for name in self.processes:

--- a/symphony/subproc/manager.py
+++ b/symphony/subproc/manager.py
@@ -92,16 +92,21 @@ class SubprocManager:
     def poll_all(self):
         return {name: self.poll(name) for name in self.processes}
 
-    def kill(self, name, verbose=False):
+    def kill(self, name, signal=signal.SIGTERM, verbose=False):
         if self.poll(name) is None:
             proc = self.processes[name]
-            proc.kill()
+            os.kill(proc.pid, signal.SIGTERM)
             if verbose:
-                print('KILLED', proc.pid)
+                print('Sent', self.SIG_DICT[signal], 'to', proc.pid)
 
     def kill_all(self, verbose=False):
         for name in self.processes:
             self.kill(name, verbose=verbose)
+        if verbose:
+            print('Making sure all subprocesses terminated...')
+        time.sleep(1)
+        for name in self.processes:
+            self.kill(name, signal=signal.SIGKILL, verbose=verbose)
 
     SIG_DICT = {
         signal.SIGINT : 'SIGINT',

--- a/symphony/subproc/manager.py
+++ b/symphony/subproc/manager.py
@@ -75,7 +75,7 @@ class SubprocManager:
             stdout=stdout,
             stderr=stderr,
             env=env,
-            preexec_fn=os.setsid
+            preexec_fn=os.setsid # put the subprocess in its own process group
         )
         self.processes[name] = proc
         return proc
@@ -96,6 +96,8 @@ class SubprocManager:
     def kill(self, name, signal=signal.SIGTERM, verbose=False):
         if self.poll(name) is None:
             proc = self.processes[name]
+
+            # send the signal to the process group containing grandchildren
             group = os.getpgid(proc.pid)
             os.killpg(group, signal)
             if verbose:


### PR DESCRIPTION
Changes introduced:
 - kill_all() first tries to send SIGTERM, instead of SIGKILL'ing right away, to let processes do some clean-up. After a second we make sure it terminated properly and if not we SIGKILL.
 - We now make each subprocess lead a process group. This way we can send the kill signal to the process group and therefore ensure that grandchildren don't remain alive. This was an issue with Surreal's replay and batch agents, which spawned off children themselves.